### PR TITLE
Removed the explicit MSVC_RUNTIME_LIBRARY

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,5 +30,3 @@ target_sources(rakhook PRIVATE
     "RakNet/PluginInterface.cpp"
     "RakNet/StringCompressor.cpp"
 )
-
-set_property(TARGET rakhook PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
RakHook has a dependency on POLYHOOK, which is compiled to STATIC by the standard, so in your code CMakeLists.txt You must specify the option to avoid conflicts.
`set(POLYHOOK_BUILD_STATIC_RUNTIME OFF)`